### PR TITLE
fix: correct client ID and add null safety for session messages

### DIFF
--- a/src/lib/gateway-client.ts
+++ b/src/lib/gateway-client.ts
@@ -238,7 +238,7 @@ export class GatewayClient {
 
         const hello = (await this.request("connect", {
           client: {
-            id: "gateway-client",
+            id: "openclaw-control-ui",
             version: "2026.2.16",
             platform: "web",
             mode: "webchat",
@@ -389,7 +389,7 @@ export class GatewayClient {
     const payload = this.buildDeviceAuthPayload({
       version: "v1",
       deviceId: identity.id,
-      clientId: "gateway-client",
+      clientId: "openclaw-control-ui",
       clientMode: "webchat",
       role: "operator",
       scopes: OPERATOR_SCOPES,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -217,7 +217,7 @@ export const useDeckStore = create<DeckStore>((set, get) => ({
       const session = state.sessions[agentId];
       if (!session) return state;
 
-      const messages = session.messages.map((msg) => {
+      const messages = (session.messages || []).map((msg) => {
         if (msg.runId === runId && msg.streaming) {
           return { ...msg, text: msg.text + chunk };
         }
@@ -242,7 +242,7 @@ export const useDeckStore = create<DeckStore>((set, get) => ({
       const session = state.sessions[agentId];
       if (!session) return state;
 
-      const messages = session.messages.map((msg) => {
+      const messages = (session.messages || []).map((msg) => {
         if (msg.runId === runId) {
           return { ...msg, streaming: false };
         }


### PR DESCRIPTION
## Problem

Two issues when connecting the Deck to a gateway over LAN:

1. **Client ID mismatch** — The Deck sends `client.id = "gateway-client"` in the WebSocket handshake, but the gateway only recognizes `"openclaw-control-ui"` as a Control UI client. This means `isControlUi` is `false`, so the `controlUi.allowInsecureAuth` and `controlUi.dangerouslyDisableDeviceAuth` settings have no effect. The gateway clears requested scopes, resulting in `missing scope: operator.write` errors on any write operation.

2. **Null reference on streaming** — `session.messages` can be `undefined` when streaming events arrive before the session's messages array is initialized, causing `TypeError: Cannot read properties of undefined (reading 'map')` in the console.

## Fix

- Changed client ID from `"gateway-client"` to `"openclaw-control-ui"` in both the connect handshake and device auth payload
- Added `|| []` null safety guards on `session.messages.map()` calls in `store.ts`

## Testing

Tested on OpenClaw 2026.2.17 connecting from a MacBook to a Mini Server over LAN. Both issues resolved — WebSocket connects with full operator scopes and no more console errors on streaming events.