### PR TITLE
Fix model badge to use active runtime source

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test \"tests/**/*.test.mjs\""
   },
   "dependencies": {
     "highlight.js": "^11.11.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,6 @@ function buildDefaultAgents(count: number): AgentConfig[] {
     icon: String(i + 1),
     accent: AGENT_ACCENTS[i % AGENT_ACCENTS.length],
     context: "",
-    model: "claude-sonnet-4-5",
   }));
 }
 

--- a/src/components/AgentColumn.tsx
+++ b/src/components/AgentColumn.tsx
@@ -10,6 +10,7 @@ import {
   useAutoScroll,
 } from "../hooks";
 import { useDeckStore } from "../lib/store";
+import { getModelDisplay } from "../lib/model-display";
 import type { AgentStatus, ChatMessage, AgentSession } from "../types";
 import styles from "./AgentColumn.module.css";
 
@@ -191,6 +192,10 @@ export function AgentColumn({ agentId, columnIndex }: { agentId: string; columnI
     session.status === "streaming" ||
     session.status === "thinking" ||
     session.status === "tool_use";
+  const modelDisplay = getModelDisplay({
+    runtimeModel: session.usage?.model,
+    configuredModel: config.model,
+  });
 
   // Determine if agent has completed work ready to review
   const lastMessage = session.messages[session.messages.length - 1];
@@ -225,11 +230,16 @@ export function AgentColumn({ agentId, columnIndex }: { agentId: string; columnI
           </div>
           <div className={styles.headerMeta}>
             {config.context ? <span>{config.context}</span> : null}
-            {config.model && (
+            {modelDisplay && (
               <>
                 {config.context ? <span className={styles.metaDot}>·</span> : null}
-                <span style={{ color: config.accent, opacity: 0.5 }}>
-                  {config.model}
+                <span
+                  style={{
+                    color: config.accent,
+                    opacity: modelDisplay.isFallback ? 0.5 : 0.85,
+                  }}
+                >
+                  {modelDisplay.sourceLabel}: {modelDisplay.model}
                 </span>
               </>
             )}

--- a/src/lib/model-display.ts
+++ b/src/lib/model-display.ts
@@ -1,0 +1,35 @@
+export interface ModelDisplayInfo {
+  model: string;
+  sourceLabel: "active runtime" | "configured";
+  isFallback: boolean;
+}
+
+interface ModelDisplayParams {
+  runtimeModel?: string | null;
+  configuredModel?: string | null;
+}
+
+export function getModelDisplay({
+  runtimeModel,
+  configuredModel,
+}: ModelDisplayParams): ModelDisplayInfo | null {
+  const runtime = runtimeModel?.trim();
+  if (runtime) {
+    return {
+      model: runtime,
+      sourceLabel: "active runtime",
+      isFallback: false,
+    };
+  }
+
+  const configured = configuredModel?.trim();
+  if (configured) {
+    return {
+      model: configured,
+      sourceLabel: "configured",
+      isFallback: true,
+    };
+  }
+
+  return null;
+}

--- a/tests/load-ts-module.mjs
+++ b/tests/load-ts-module.mjs
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import ts from 'typescript';
+
+export async function loadTsModule(tsPath) {
+  const source = await readFile(tsPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+    fileName: tsPath,
+  });
+
+  const outPath = join(tmpdir(), `${basename(tsPath, '.ts')}-${Date.now()}.mjs`);
+  await writeFile(outPath, transpiled.outputText, 'utf8');
+  return import(pathToFileURL(outPath).href);
+}

--- a/tests/model-display.test.mjs
+++ b/tests/model-display.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadTsModule } from './load-ts-module.mjs';
+
+async function getResolver() {
+  const mod = await loadTsModule('src/lib/model-display.ts');
+  return mod.getModelDisplay;
+}
+
+test('prefers runtime model when present and labels as active runtime', async () => {
+  const getModelDisplay = await getResolver();
+  const display = getModelDisplay({
+    configuredModel: 'claude-sonnet-4-5',
+    runtimeModel: 'openai-codex/gpt-5.3-codex',
+  });
+
+  assert.deepEqual(display, {
+    model: 'openai-codex/gpt-5.3-codex',
+    sourceLabel: 'active runtime',
+    isFallback: false,
+  });
+});
+
+test('falls back to configured model and labels it clearly', async () => {
+  const getModelDisplay = await getResolver();
+  const display = getModelDisplay({
+    configuredModel: 'claude-sonnet-4-5',
+  });
+
+  assert.deepEqual(display, {
+    model: 'claude-sonnet-4-5',
+    sourceLabel: 'configured',
+    isFallback: true,
+  });
+});
+
+test('returns null when no runtime or configured model is available', async () => {
+  const getModelDisplay = await getResolver();
+  const display = getModelDisplay({});
+
+  assert.equal(display, null);
+});


### PR DESCRIPTION
## Summary
- prefer runtime model from session usage when rendering agent header model badge
- clearly label source (active runtime vs configured fallback)
- remove misleading hardcoded default model on initial agents
- add focused tests for model display precedence and null behavior

## Validation
- node --test tests/model-display.test.mjs
- npm run build

## Commit
- 23098b7