### PR TITLE
fix syntax getting gateway token

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ openclaw gateway start
 Your gateway token is required for authentication:
 
 ```bash
-openclaw config get gateway.token
+openclaw config get gateway.auth.token
 ```
 
 **Example output:**


### PR DESCRIPTION
The current "gateway.token" path gives `Config path not found: gateway.token`, so I checked with "openclaw config get gateway" to inspect the path:

```
{
  "port": 18789,
  "mode": "local",
  "bind": "loopback",
  "auth": {
    "mode": "token",
    "token": "<redacted>"
  },
  "tailscale": {
    "mode": "serve",
    "resetOnExit": true
  },
  "nodes": {
    "denyCommands": [
      "canvas.present",
      "canvas.hide",
      "canvas.navigate",
      "canvas.eval",
      "canvas.snapshot",
      "canvas.a2ui.push",
      "canvas.a2ui.pushJSONL",
      "canvas.a2ui.reset"
    ]
  }
}
```