### PR TITLE
feat: Dynamic model fetching from OpenClaw Gateway

### DIFF
--- a/src/components/AddAgentModal.tsx
+++ b/src/components/AddAgentModal.tsx
@@ -1,6 +1,7 @@
 import { useState, type KeyboardEvent } from "react";
 import type { AgentConfig } from "../types";
 import styles from "./AddAgentModal.module.css";
+import { FALLBACK_MODELS } from "../lib/gateway-config";
 
 const ACCENTS = [
   "#22d3ee", // cyan
@@ -13,23 +14,27 @@ const ACCENTS = [
   "#ef4444", // red
 ];
 
-const MODELS = [
-  "claude-sonnet-4-5",
-  "claude-opus-4-6",
-];
+interface AddAgentModalProps {
+  onClose: () => void;
+  onCreate: (agent: AgentConfig) => Promise<void>;
+  availableModels?: Array<{ id: string; name: string }>;
+  defaultModel?: string;
+}
 
 export function AddAgentModal({
   onClose,
   onCreate,
-}: {
-  onClose: () => void;
-  onCreate: (agent: AgentConfig) => Promise<void>;
-}) {
+  availableModels,
+  defaultModel,
+}: AddAgentModalProps) {
+  const models = (availableModels && availableModels.length > 0) ? availableModels : FALLBACK_MODELS;
+  const initialModel = defaultModel || (models[0]?.id ?? FALLBACK_MODELS[0].id);
+
   const [name, setName] = useState("");
   const [icon, setIcon] = useState("");
   const [accent, setAccent] = useState(ACCENTS[1]);
   const [context, setContext] = useState("");
-  const [model, setModel] = useState(MODELS[0]);
+  const [model, setModel] = useState(initialModel);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -131,8 +136,8 @@ export function AddAgentModal({
             value={model}
             onChange={(e) => setModel(e.target.value)}
           >
-            {MODELS.map((m) => (
-              <option key={m} value={m}>{m}</option>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
             ))}
           </select>
         </div>

--- a/src/lib/gateway-config.ts
+++ b/src/lib/gateway-config.ts
@@ -1,0 +1,107 @@
+import type { AgentConfig } from "../types";
+
+// Fallback model if gateway fetch fails
+export const FALLBACK_MODEL = "claude-sonnet-4-5";
+
+// Fallback models list for AddAgentModal
+export const FALLBACK_MODELS = [
+  { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+];
+
+export interface GatewayInfo {
+  defaultModel: string;
+  availableModels: Array<{ id: string; name: string }>;
+}
+
+/**
+ * Fetch gateway configuration including available models.
+ * Falls back to hardcoded defaults if fetch fails.
+ */
+export async function fetchGatewayConfig(
+  gatewayUrl: string,
+  token?: string
+): Promise<GatewayInfo> {
+  try {
+    // Use relative path to go through Vite proxy and avoid CORS
+    const configUrl = "/config";
+
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(configUrl, { headers });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const config = await response.json();
+
+    // Extract models from gateway config
+    const models = config.agents?.defaults?.models || {};
+    const modelList = Object.entries(models).map(([id, info]: [string, unknown]) => {
+      const modelInfo = info as { alias?: string };
+      return {
+        id,
+        name: modelInfo.alias || id.split("/").pop() || id,
+      };
+    });
+
+    // Get default model from primary config
+    const defaultModel =
+      config.agents?.defaults?.model?.primary ||
+      modelList[0]?.id ||
+      FALLBACK_MODEL;
+
+    return {
+      defaultModel,
+      availableModels: modelList.length > 0 ? modelList : FALLBACK_MODELS,
+    };
+  } catch (err) {
+    console.warn("[GatewayConfig] Failed to fetch, using fallback:", err);
+    return {
+      defaultModel: FALLBACK_MODEL,
+      availableModels: FALLBACK_MODELS,
+    };
+  }
+}
+
+/**
+ * Build default agents with dynamic model from gateway config.
+ */
+export function buildDefaultAgents(
+  count: number,
+  defaultModel: string = FALLBACK_MODEL
+): AgentConfig[] {
+  const AGENT_ACCENTS = [
+    "#22d3ee",
+    "#a78bfa",
+    "#34d399",
+    "#f59e0b",
+    "#f472b6",
+    "#60a5fa",
+    "#facc15",
+    "#fb7185",
+    "#4ade80",
+    "#c084fc",
+    "#f97316",
+    "#2dd4bf",
+  ];
+
+  return Array.from({ length: count }, (_, i) => {
+    const agentId = i === 0 ? "main" : `agent-${i + 1}`;
+    const agentName = i === 0 ? "Main" : `Agent ${i + 1}`;
+
+    return {
+      id: agentId,
+      name: agentName,
+      icon: String(i + 1),
+      accent: AGENT_ACCENTS[i % AGENT_ACCENTS.length],
+      context: "",
+      model: defaultModel,
+    };
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/ws/, ""),
       },
+      "/config": {
+        target: "http://127.0.0.1:18789",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
- Added gateway-config.ts to fetch available models from gateway /config endpoint
- Models are fetched dynamically on app load from local gateway
- Falls back to static defaults if fetch fails
- Added Vite proxy for /config to avoid CORS issues
- useDeckInit now properly re-initializes when agent models change
- Columns display the actual default model from gateway config
- AddAgentModal receives models via props instead of hardcoded list

Enables custom dashboards like OpenClaw Deck to dynamically fetch models from the OpenClaw Gateway configuration.